### PR TITLE
Removing P-224 from ecdh_curves

### DIFF
--- a/lib/localhost/authority.rb
+++ b/lib/localhost/authority.rb
@@ -126,7 +126,7 @@ module Localhost
 				end
 				
 				if context.respond_to? :ecdh_curves=
-					context.ecdh_curves = 'P-256:P-384:P-224:P-521'
+					context.ecdh_curves = 'P-256:P-384:P-521'
 				elsif context.respond_to? :tmp_ecdh_callback=
 					context.tmp_ecdh_callback = proc {self.ecdh_key}
 				end


### PR DESCRIPTION
## Descriptions

This pull request removes P-224 from ecdh_curves group in localhost.
This is expected to fix an issue where localhost will not run in some CentOS environment due to OpenSSL not recognizing P-224 as an option.

This request is created to address issue #7 .