### PR TITLE
Update examples to align with latest async/http gem

### DIFF
--- a/examples/https.rb
+++ b/examples/https.rb
@@ -13,7 +13,7 @@ authority = Localhost::Authority.fetch(hostname)
 
 # The server app:
 app = lambda do |request|
-	Async::HTTP::Response[200, {}, ["Hello World!"]]
+  Protocol::HTTP::Response[200, {}, ["Hello World"]]
 end
 
 # Bind to the specified host:
@@ -21,11 +21,11 @@ endpoint = Async::IO::Endpoint.tcp(hostname, "8080")
 
 # Prepare the server, endpoint will be used for `bind`:
 server_endpoint = Async::IO::SSLEndpoint.new(endpoint, ssl_context: authority.server_context)
-server = Async::HTTP::Server.new(app, server_endpoint, Async::HTTP::Protocol::HTTP1)
+server = Async::HTTP::Server.new(app, server_endpoint, protocol: Async::HTTP::Protocol::HTTP1, scheme: "https")
 
 # Prepare the client, endpoint will be used for `connect`:
 client_endpoint = Async::IO::SSLEndpoint.new(endpoint, ssl_context: authority.client_context)
-client = Async::HTTP::Client.new(client_endpoint, Async::HTTP::Protocol::HTTP1)
+client = Async::HTTP::Client.new(client_endpoint, protocol: Async::HTTP::Protocol::HTTP1, scheme: "https", authority: authority)
 
 # Run the reactor:
 Async::Reactor.run do |task|
@@ -33,11 +33,11 @@ Async::Reactor.run do |task|
 	server_task = task.async do
 		server.run
 	end
-	
+
 	# Connect to the server:
 	response = client.get("/")
 	puts "Status: #{response.status}\n#{response.read}"
-	
+
 	# Stop the server:
 	server_task.stop
 end


### PR DESCRIPTION
## Update examples/https.rb to work with latest async/http gem

The example https.rb in examples folder is out of date and can not be able run. I have updated the example to align with latest async/http gem. 

### Types of Changes 

- Bug fix.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
