### PR TITLE
fix: README Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Please see the [project documentation](https://socketry.github.io/localhost/).
 
 ## See Also
 
-	- [Falcon](https://github.com/socketry/falcon) — Uses `Localhost::Authority` to provide HTTP/2 with minimal configuration.
-	- [Puma](https://github.com/puma/puma) — Supports `Localhost::Authority` to provide self-signed HTTP for local development.
+- [Falcon](https://github.com/socketry/falcon) — Uses `Localhost::Authority` to provide HTTP/2 with minimal configuration.
+- [Puma](https://github.com/puma/puma) — Supports `Localhost::Authority` to provide self-signed HTTP for local development.
 
 ## License
 


### PR DESCRIPTION


## Description

Avoid monospace font in a list in README.

<img width="1125" alt="bild" src="https://user-images.githubusercontent.com/211/133965969-dd3f68e3-2448-4d7d-995a-309cf7bf6319.png">

### Types of Changes


- Maintenance.

### Testing

n/a