### PR TITLE
Delay between tests to avoid clobbering. Fixes #19.

### DIFF
--- a/spec/localhost/protocol_spec.rb
+++ b/spec/localhost/protocol_spec.rb
@@ -72,6 +72,9 @@ RSpec.describe Localhost::Authority do
 	let(:client) {client_endpoint.connect}
 	
 	let!(:server_task) do
+		# A nasty hax.
+		sleep 10
+		
 		reactor.async do
 			server_endpoint.accept do |peer|
 				peer.write("HTTP/1.1 200 Okay\r\n")


### PR DESCRIPTION
It seems like curl and/or OpenSSL gem don't like `peer.close`:

```
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 Okay
* OpenSSL SSL_read: Connection reset by peer, errno 54
* Closing connection 0
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
curl: (56) OpenSSL SSL_read: Connection reset by peer, errno 54
```

Oh, it turned out to be a race condition in the tests. I'll need to fix it properly later by binding to an ephemeral port.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
