### PR TITLE
Change the directory certificates are stored in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /gems.locked
 /.covered.db
 /external
+/state

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -5,4 +5,6 @@
 
 require 'covered/sus'
 include Covered::Sus
+
+require 'fileutils'
 FileUtils.mkdir_p(::File.expand_path(ENV['XDG_STATE_HOME'] || "~/.local/state"))

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -7,4 +7,6 @@ require 'covered/sus'
 include Covered::Sus
 
 require 'fileutils'
+
+require 'fileutils'
 FileUtils.mkdir_p(::File.expand_path(ENV['XDG_STATE_HOME'] || "~/.local/state"))

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -5,3 +5,4 @@
 
 require 'covered/sus'
 include Covered::Sus
+FileUtils.mkdir_p(::File.expand_path(ENV['XDG_STATE_HOME'] || "~/.local/state"))

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -7,6 +7,4 @@ require 'covered/sus'
 include Covered::Sus
 
 require 'fileutils'
-
-require 'fileutils'
 FileUtils.mkdir_p(::File.expand_path(ENV['XDG_STATE_HOME'] || "~/.local/state"))

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -5,6 +5,3 @@
 
 require 'covered/sus'
 include Covered::Sus
-
-require 'fileutils'
-FileUtils.mkdir_p(::File.expand_path(ENV['XDG_STATE_HOME'] || "~/.local/state"))

--- a/guides/getting-started/README.md
+++ b/guides/getting-started/README.md
@@ -18,7 +18,7 @@ $ bundle add localhost
 
 ### Files
 
-The certificate and private key are stored in `~/.localhost/`. You can delete them and they will be regenerated. If you added the certificate to your computer's certificate store/keychain, you'll you'd need to update it.
+The certificate and private key are stored in `$XDG_STATE_HOME/localhost.rb/` (defaulting to `~/.local/state/localhost.rb/`). You can delete them and they will be regenerated. If you added the certificate to your computer's certificate store/keychain, you'll you'd need to update it.
 
 ## Usage
 

--- a/lib/localhost/authority.rb
+++ b/lib/localhost/authority.rb
@@ -8,11 +8,14 @@
 # Copyright, 2023, by Antonio Terceiro.
 # Copyright, 2023, by Yuuji Yaginuma.
 
+require 'fileutils'
 require 'openssl'
 
 module Localhost
 	# Represents a single public/private key pair for a given hostname.
 	class Authority
+		# Where to store the key pair on the filesystem. This is a subdirectory
+		# of $XDG_STATE_HOME, or ~/.local/state/ when that's not defined.
 		def self.path
 			File.expand_path("localhost.rb", ENV.fetch("XDG_STATE_HOME", "~/.local/state"))
 		end
@@ -176,29 +179,27 @@ module Localhost
 		end
 		
 		def load(path = @root)
-			migrate_legacy_authority_path(path)
-			if File.directory?(path)
-				certificate_path = File.join(path, "#{@hostname}.crt")
-				key_path = File.join(path, "#{@hostname}.key")
-				
-				return false unless File.exist?(certificate_path) and File.exist?(key_path)
-				
-				certificate = OpenSSL::X509::Certificate.new(File.read(certificate_path))
-				key = OpenSSL::PKey::RSA.new(File.read(key_path))
-				
-				# Certificates with old version need to be regenerated.
-				return false if certificate.version < 2
-				
-				@certificate = certificate
-				@key = key
-				
-				return true
-			end
+			ensure_authority_path_exists(path)
+			
+			certificate_path = File.join(path, "#{@hostname}.crt")
+			key_path = File.join(path, "#{@hostname}.key")
+						
+			return false unless File.exist?(certificate_path) and File.exist?(key_path)
+			
+			certificate = OpenSSL::X509::Certificate.new(File.read(certificate_path))
+			key = OpenSSL::PKey::RSA.new(File.read(key_path))
+			
+			# Certificates with old version need to be regenerated.
+			return false if certificate.version < 2
+			
+			@certificate = certificate
+			@key = key
+			
+			return true
 		end
 		
 		def save(path = @root)
-			migrate_legacy_authority_path(path)
-			Dir.mkdir(path, 0700) unless File.directory?(path)
+			ensure_authority_path_exists(path)
 			
 			lockfile_path = File.join(path, "#{@hostname}.lock")
 			
@@ -216,13 +217,18 @@ module Localhost
 				)
 			end
 		end
-
-		# Migrates the legacy dir ~/.localhost/ to the XDG compliant directory,
-		# if it exists but the new location does not.
-		def migrate_legacy_authority_path(path = @root)
+		
+		# Ensures that the directory to store the certificate exists. If the legacy
+		# directory (~/.localhost/) exists, it is moved into the new XDG Basedir
+		# compliant directory.
+		def ensure_authority_path_exists(path = @root)
 			old_root = File.expand_path("~/.localhost")
+			
 			if File.directory?(old_root) and not File.directory?(path)
+				# Migrates the legacy dir ~/.localhost/ to the XDG compliant directory
 				File.rename(old_root, path)
+			elsif not File.directory?(path)
+				FileUtils.makedirs(path, mode: 0700)
 			end
 		end
 	end

--- a/test/localhost/authority.rb
+++ b/test/localhost/authority.rb
@@ -32,7 +32,6 @@ describe Localhost::Authority do
 	end
 	
 	it "can generate key and certificate" do
-		FileUtils.mkdir_p("ssl")
 		authority.save("ssl")
 		
 		expect(File).to be(:exist?, "ssl/localhost.lock")
@@ -41,7 +40,6 @@ describe Localhost::Authority do
 	end
 	
 	it "have correct key and certificate path" do
-		FileUtils.mkdir_p(xdg_dir)
 		authority.save(authority.class.path)
 		expect(File).to be(:exist?, authority.certificate_path)
 		expect(File).to be(:exist?, authority.key_path)


### PR DESCRIPTION
The new directory is compliant with the [XDG Basedir specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

The library will migrate the old directory to the new directory when it is not destructive.

Closes #27 .

## Types of Changes

- New feature.
- Breaking change.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
